### PR TITLE
Use an rc package instead of a regular one.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/react-native-ledger-core",
   "description": "Ledger Core Library bindings for React Native",
-  "version": "0.4.0",
+  "version": "0.4.0-rc.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will prevent accidental use without explicit consent.