### PR TITLE
Add Android x86_64

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LedgerHQ/lib-ledger-core-node-bindings"
+    "url": "https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "preinstall": "bash preinstall.sh"
   },
   "peerDependencies": {
-    "react-native": "0.55.4"
+    "react-native": "^0.59.0"
   },
   "devDependencies": {}
 }

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -6,7 +6,7 @@
 #                              Preinstall script
 #
 
-LIB_CORE_VERSION="2.7.0-rc-6cc3ea"
+LIB_CORE_VERSION="2.7.0-rc-663496"
 BASE_URL="https://s3-eu-west-1.amazonaws.com/ledger-lib-ledger-core"
 
 function main() {
@@ -21,6 +21,7 @@ function main() {
   dl "ledger-core.framework/ledger-core"  "ios/universal"         "ios/Frameworks"
   dl "ledger-core.framework/Info.plist"   "ios/universal"         "ios/Frameworks"
   dl "libledger-core.so"                  "android/x86"           "android/libs"
+  dl "libledger-core.so"                  "android/x86_64"        "android/libs"
   dl "libledger-core.so"                  "android/armeabi-v7a"   "android/libs"
   dl "libledger-core.so"                  "android/arm64-v8a"     "android/libs"
 }


### PR DESCRIPTION
Since LedgerHQ/lib-ledger-core#233 lib-ledger-core ships Android x86_64 binaries.
This add them.

### Context

https://ledgerhq.atlassian.net/browse/LL-1406