### PR TITLE
Avoid resolving twice a promise

### DIFF
--- a/android/src/main/java/com/ledger/reactnative/RCTCoreDatabaseStatement.java
+++ b/android/src/main/java/com/ledger/reactnative/RCTCoreDatabaseStatement.java
@@ -261,7 +261,6 @@ public class RCTCoreDatabaseStatement extends ReactContextBaseJavaModule {
             DatabaseBlobImpl javaParam_1_java = (DatabaseBlobImpl)javaParam_1;
             javaParam_1_java.setPromise(promise);
             currentInstanceObj.bindBlob(pos, javaParam_1);
-            promise.resolve(0);
         }
         catch(Exception e)
         {

--- a/android/src/main/java/com/ledger/reactnative/RCTCoreEventBus.java
+++ b/android/src/main/java/com/ledger/reactnative/RCTCoreEventBus.java
@@ -124,7 +124,6 @@ public class RCTCoreEventBus extends ReactContextBaseJavaModule {
             EventReceiverImpl javaParam_1_java = (EventReceiverImpl)javaParam_1;
             javaParam_1_java.setPromise(promise);
             currentInstanceObj.subscribe(javaParam_0, javaParam_1);
-            promise.resolve(0);
         }
         catch(Exception e)
         {
@@ -148,7 +147,6 @@ public class RCTCoreEventBus extends ReactContextBaseJavaModule {
             EventReceiverImpl javaParam_0_java = (EventReceiverImpl)javaParam_0;
             javaParam_0_java.setPromise(promise);
             currentInstanceObj.unsubscribe(javaParam_0);
-            promise.resolve(0);
         }
         catch(Exception e)
         {

--- a/android/src/main/java/com/ledger/reactnative/RCTCoreHttpRequest.java
+++ b/android/src/main/java/com/ledger/reactnative/RCTCoreHttpRequest.java
@@ -247,7 +247,6 @@ public class RCTCoreHttpRequest extends ReactContextBaseJavaModule {
             RCTCoreError rctParam_error = this.reactContext.getNativeModule(RCTCoreError.class);
             Error javaParam_1 = rctParam_error.getJavaObjects().get(error.get().getString("uid"));
             currentInstanceObj.complete(javaParam_0, javaParam_1);
-            promise.resolve(0);
         }
         catch(Exception e)
         {

--- a/ios/Sources/react-native-ios/RCTCoreLGDatabaseStatement.m
+++ b/ios/Sources/react-native-ios/RCTCoreLGDatabaseStatement.m
@@ -204,7 +204,6 @@ RCT_REMAP_METHOD(bindBlob,bindBlob:(NSDictionary *)currentInstance withParams:(i
         objcParam_1_objc.reject = reject;
     }
     [currentInstanceObj bindBlob:pos value:objcParam_1];
-    resolve(@(YES));
 
 }
 

--- a/ios/Sources/react-native-ios/RCTCoreLGEventBus.m
+++ b/ios/Sources/react-native-ios/RCTCoreLGEventBus.m
@@ -68,7 +68,6 @@ RCT_REMAP_METHOD(subscribe,subscribe:(NSDictionary *)currentInstance withParams:
         objcParam_1_objc.reject = reject;
     }
     [currentInstanceObj subscribe:objcParam_0 receiver:objcParam_1];
-    resolve(@(YES));
 
 }
 
@@ -98,7 +97,6 @@ RCT_REMAP_METHOD(unsubscribe,unsubscribe:(NSDictionary *)currentInstance withPar
         objcParam_0_objc.reject = reject;
     }
     [currentInstanceObj unsubscribe:objcParam_0];
-    resolve(@(YES));
 
 }
 @end

--- a/ios/Sources/react-native-ios/RCTCoreLGHttpRequest.m
+++ b/ios/Sources/react-native-ios/RCTCoreLGHttpRequest.m
@@ -186,7 +186,6 @@ RCT_REMAP_METHOD(complete,complete:(NSDictionary *)currentInstance withParams:(n
     RCTCoreLGError *rctParam_error = (RCTCoreLGError *)[self.bridge moduleForName:@"CoreLGError"];
     LGError *objcParam_1 = (LGError *)[rctParam_error.objcImplementations objectForKey:error[@"uid"]];
     [currentInstanceObj complete:objcParam_0 error:objcParam_1];
-    resolve(@(YES));
 
 }
 @end


### PR DESCRIPTION
Due to previous commit which was resolving promises for sync methods with no return value.
Unfortunately, in this case if one of the parameters is an object from specific implementation, it also tries to resolve the same promise which is, of course, not allowed !