### PR TITLE
Actually working podspecs

### DIFF
--- a/RNLibLedgerCore.podspec
+++ b/RNLibLedgerCore.podspec
@@ -1,0 +1,22 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                = 'RNLibLedgerCore'
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.homepage            = 'https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings'
+  s.license             = package['license']
+  s.author              = 'Ledger'
+  s.source              = { :git => 'https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings.git', :tag => "v#{package['version']}" }
+  s.requires_arc        = true
+  s.platform            = :ios, '8.0'
+  s.source_files         = 'ios/**/*.{h,m}'
+
+  s.vendored_frameworks = 'ios/Frameworks/universal/ledger-core.framework'
+  s.vendored_library    = 'libledger-core-objc.a'
+
+  s.dependency          'ledger-core-objc'
+  s.dependency          'React'
+end

--- a/djinni_objc.podspec
+++ b/djinni_objc.podspec
@@ -1,0 +1,15 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                = 'djinni_objc'
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.homepage            = 'https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings'
+  s.license             = package['license']
+  s.author              = 'Ledger'
+  s.source              = { :git => 'https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings.git', :tag => "v#{package['version']}" }
+  s.platform            = :ios, '8.0'
+  s.source_files        = 'support-lib/objc/*.{h,mm}'
+end

--- a/ledger-core-objc.podspec
+++ b/ledger-core-objc.podspec
@@ -3,16 +3,18 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name                = 'ledgerhq-react-native-ledger-core'
+  s.name                = 'ledger-core-objc'
   s.version             = package['version']
   s.summary             = package['description']
   s.homepage            = 'https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings'
   s.license             = package['license']
   s.author              = 'Ledger'
   s.source              = { :git => 'https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings.git', :tag => "v#{package['version']}" }
-  s.requires_arc        = true
-  s.platform            = :ios, '9.0'
-  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
-  s.source_files        = 'ios/*.{h,m,mm}'
-  s.dependency          'React'
+  s.platform            = :ios, '8.0'
+  s.source_files         = 'ios/**/*.{h,mm,hpp}'
+
+  s.vendored_library    = 'libdjinni_objc.a'
+
+  s.dependency          'djinni_objc'
+
 end


### PR DESCRIPTION
### Caveats

Because of the need to build 3 libs, React Native new _autolink_ feature won't work out of the box so we still need to add the following lines to Ledger Live Mobile `Podfile` :

```
  pod 'djinni_objc', :path => '../node_modules/@ledgerhq/react-native-ledger-core'
  pod 'ledger-core-objc', :path => '../node_modules/@ledgerhq/react-native-ledger-core'
  pod 'RNLibLedgerCore', :path => '../node_modules/@ledgerhq/react-native-ledger-core'
```

Also podspecs don't offer enough flexibility to replicate our trick to selectively add x86 version of `ledger-core.framework` only for simulator, so this part has to stay in the Ledger Live Mobile project