### PR TITLE
[Android] React Native 0.61 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,30 +1,29 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.5.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 29
 
     sourceSets {
         main {
-            java.srcDirs = ['src']
-            jni.srcDirs = []
+            java.srcDirs = ['src/main/java']
             jniLibs.srcDirs = ['libs']
         }
     }
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 25
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }
@@ -35,9 +34,18 @@ android {
 }
 
 repositories {
-    mavenCentral()
+  google()
+  jcenter()
+  mavenCentral()
+  maven { url "https://jitpack.io" }
+  maven {
+    // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+    url "$rootDir/../node_modules/react-native/android"
+  }
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+  implementation 'com.facebook.react:react-native:+'
+  implementation "androidx.annotation:annotation:1.0.0"
+  implementation "androidx.legacy:legacy-support-v4:1.0.0"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -16,5 +16,3 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-android.useDeprecatedNdk=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 02 15:59:09 CEST 2018
+#Mon Oct 21 14:46:26 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
- Updated gradle scripts.
- Removed calls to `WritableNativeMap.setUseNativeAccessor` which has been [removed from React Native](https://github.com/facebook/react-native/commit/b257e06bc6c29236a1a19f645fb46b85b2ffc4d2).
AFAICT it was some private API which was used as a workaround by third party libs to a bug in older React Native versions, so this shouldn't bring any issue 🤞