### PR TITLE
Prevent HTTP client to override set HTTP headers 

### DIFF
--- a/android/src/main/java/com/ledger/reactnative/HttpClientImpl.java
+++ b/android/src/main/java/com/ledger/reactnative/HttpClientImpl.java
@@ -55,8 +55,12 @@ public class HttpClientImpl extends co.ledger.core.HttpClient {
                     byte[] body = request.getBody();
                     if (body.length > 0) {
                         connection.setRequestMethod( "POST" );
-                        connection.setRequestProperty( "Content-Type", "application/json");
-                        connection.setRequestProperty( "Content-Encoding", "UTF-8");
+                        if (!headers.containsKey("Content-Type")) {
+                            connection.setRequestProperty( "Content-Type", "application/json");
+                        }
+                        if (!headers.containsKey("Content-Encoding")) {
+                            connection.setRequestProperty( "Content-Encoding", "UTF-8");
+                        }
                         connection.setRequestProperty( "Content-Length", Integer.toString(body.length));
                         OutputStream os = connection.getOutputStream();
                         os.write(body);

--- a/ios/Sources/objc-impl/LGHttpClientImpl.m
+++ b/ios/Sources/objc-impl/LGHttpClientImpl.m
@@ -21,7 +21,9 @@
     NSData *body = [request getBody];
     if ([body length] > 0) {
         [urlRequest setHTTPMethod:@"POST"];
-        [urlRequest setValue: @"application/json" forHTTPHeaderField: @"Content-Type"];
+        if ([headers objectForKey: @"Content-Type"] == nil) {
+            [urlRequest setValue: @"application/json" forHTTPHeaderField: @"Content-Type"];
+        }
         NSString * dataLength = [NSString stringWithFormat: @"%ld", [body length]];
         [urlRequest setValue: dataLength forHTTPHeaderField: @"Content-Length"];
         [urlRequest setHTTPBody:body];


### PR DESCRIPTION
`Content-Type` and `Content-Encoding` are overriden by the HTTP client. 
This prevents some integration which are not using `application/json` to work.