### PR TITLE
Spring cleaning 🧹

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-/lib
-/android/libs
-/ios/Libraries

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -12,18 +12,15 @@ BASE_URL="https://s3-eu-west-1.amazonaws.com/ledger-lib-ledger-core"
 function main() {
   #  lib file                             architecture            destination       arch override
   #  ---------------------------------------------------------------------------------------------
-  dl "ledger-core.framework/ledger-core"  "ios/x86_64"            "ios/Frameworks"  "x86"
-  dl "ledger-core.framework/Info.plist"   "ios/x86_64"            "ios/Frameworks"  "x86"
-  dl "ledger-core.framework/ledger-core"  "ios/armv7"             "ios/Frameworks"
-  dl "ledger-core.framework/Info.plist"   "ios/armv7"             "ios/Frameworks"
-  dl "ledger-core.framework/ledger-core"  "ios/arm64"             "ios/Frameworks"
-  dl "ledger-core.framework/Info.plist"   "ios/arm64"             "ios/Frameworks"
-  dl "ledger-core.framework/ledger-core"  "ios/universal"         "ios/Frameworks"
-  dl "ledger-core.framework/Info.plist"   "ios/universal"         "ios/Frameworks"
   dl "libledger-core.so"                  "android/x86"           "android/libs"
   dl "libledger-core.so"                  "android/x86_64"        "android/libs"
   dl "libledger-core.so"                  "android/armeabi-v7a"   "android/libs"
   dl "libledger-core.so"                  "android/arm64-v8a"     "android/libs"
+
+  if [[ $(uname) == "Darwin" ]]; then
+    dl "ledger-core.framework/ledger-core"  "ios/universal"       "ios/Frameworks"
+    dl "ledger-core.framework/Info.plist"   "ios/universal"       "ios/Frameworks"
+  fi
 }
 
 function dl() {


### PR DESCRIPTION
- Only download iOS libcore on Mac (since only this OS can build iOS anyway)
- Only download the _fat_ version of iOS libcore framework (needs LedgerHQ/lib-ledger-core#545 to be merged in)
- Deleted leftover `.npmignore` file which prevented `npm publish` to follow `.gitignore` and thus pushed a lot of useless files