### PR TITLE
Remove Algorand API token

### DIFF
--- a/android/src/main/java/co/ledger/core/AlgorandConfigurationDefaults.java
+++ b/android/src/main/java/co/ledger/core/AlgorandConfigurationDefaults.java
@@ -5,9 +5,9 @@ package co.ledger.core;
 
 public final class AlgorandConfigurationDefaults {
 
-    public static final String ALGORAND_API_ENDPOINT = "https://mainnet-algorand.api.purestake.io";
+    public static final String ALGORAND_API_ENDPOINT = "DISABLED";
 
-    public static final String ALGORAND_API_TOKEN = "51QbkNgumz6aMzgl7qL2FabvZsREiCyw6VLcuNCj";
+    public static final String ALGORAND_API_TOKEN = "DISABLED";
 
     /** TODO Find an observer endpoint?? */
     public static final String ALGORAND_OBSERVER_WS_ENDPOINT = "";


### PR DESCRIPTION
The API token was revoked right after it was introduced in the code, and in fact it was never actually used. But the value remained, which made some people think they found a security vulnerabilities in Ledger Live. Remove the API token to prevent more false-positive security reports from happening.